### PR TITLE
feat: Add detection of images in child of a block + Add DEBUG environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ services:
       - MICROSOFT_API_KEY=9834023jdsadlawdkwn
       - MICROSOFT_ENDPOINT=https://[YOUR_NAME].cognitiveservices.azure.com/
       - SCAN_METHOD=checkbox 
-      - SCAN_FREQUENCY=15 # Optional 
+      - SCAN_FREQUENCY=15 # Optional
+      - DEBUG=True #Optional
 ```
 
 ### Environment variables
@@ -45,6 +46,7 @@ services:
 * **MICROSOFT_ENDPOINT**: Url of your API end-point. Can be retrieved from the Azure Portal
 * **SCAN_METHOD**: Method used to scan page including new image to parse. Valid value is checkbox or createtime
 * **SCAN_FREQUENCY**: Optional parameter to set the frequency of scanning for new images to parse. Leave out to do a single run (recommended for testing)
+* **DEBUG**: Optional parameter to enable debug logs. Only for debuging purpose
 
 ## Usage
 The script checks if it can find the 'ocr_text' text in image caption or under an image. If it does, it will send the content of the image to Microsoft OCR API and replace the 'ocr_text' by the result in caption or add the result at the end of the current document. When the 'SCAN_FREQUENCY' environment variable is set, it will check if there are any new pages added since the last scan (through the use of setting timestamps).


### PR DESCRIPTION
This pull request introduces a new optional debug feature to the application, which allows for more detailed logging during execution. The most important changes include updates to the `README.md` to document the new `DEBUG` environment variable, and modifications to `app.py` to implement the debug logging functionality.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R39): Added `DEBUG` environment variable to the list of configuration options, allowing users to enable debug logs for troubleshooting purposes. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R39) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R49)

Codebase updates:

* [`app.py`](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R150-R156): Support of image search in children block (like column_list but not limited to) without level limitation. Now, if block have has_children property to True, we follow the child block

* [`app.py`](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R17): Introduced the `DEBUG` environment variable to control debug logging. The `DEBUG` variable is set based on the environment configuration.
* [`app.py`](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R77-R79): Added debug logging statements within the `get_scan_request_body`, `read_database`, and `get_images_to_scan_in_page` functions to provide detailed output when `DEBUG` is enabled. [[1]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R77-R79) [[2]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R110-R123) [[3]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R148-R156) [[4]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R189-L174)